### PR TITLE
Update read_hbv.c

### DIFF
--- a/src/read_hbv.c
+++ b/src/read_hbv.c
@@ -88,7 +88,7 @@ void ReadHbvResults(const char dir[], int nsub, int *nsteps, int *steps[], subca
         // Add residual moisture
         for (kstep = 0; kstep < *nsteps; kstep++)
         {
-            subcatch[ksub].ws[kstep][SURFACE] += STORAGE_MIN;   // 2021-05-14
+            subcatch[ksub].ws[kstep][SURFACE] += subcatch[ksub].res_surface;   // 2021-05-14
             subcatch[ksub].ws[kstep][UZ] += subcatch[ksub].res_uz;
             subcatch[ksub].ws[kstep][LZ] += subcatch[ksub].res_lz;
         }


### PR DESCRIPTION
The user input residual surface storage wasn't used previously. The edit corrects for it.